### PR TITLE
fixed CERTIFICATE_VERIFY_FAILED error when accessing OpenWeather API

### DIFF
--- a/components/weatherinfo.py
+++ b/components/weatherinfo.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Union
 from urllib import request as urlreq, parse as urlparse
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 
 import iterm2
 


### PR DESCRIPTION
fixed #5 

The error was caused by the SSL certificate (I don't know the true reason why it has happened but I guess it is because OpenWeather has changed their SSL certificate or something...)

Error message:
```python
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)
```